### PR TITLE
Update polyfills.ts

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -16,4 +16,4 @@ import 'core-js/es6/set';
 import 'core-js/es6/reflect';
 
 import 'core-js/es7/reflect';
-// import 'zone.js/dist/zone';
+import 'zone.js/dist/zone';


### PR DESCRIPTION
Was getting error: `Angular requires Zone.js prolyfill.`, and noticed this line was commented out.  This was after a fresh git clone.  Uncommenting this line fixed the issue.